### PR TITLE
Make PathExists work

### DIFF
--- a/PathExists.py
+++ b/PathExists.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env ./python-2.6.sh
+#!/usr/bin/env ./batchprofiler.sh
 """
 CellProfiler is distributed under the GNU General Public License.
 See the accompanying file LICENSE for details.


### PR DESCRIPTION
This is a fix to PathExists.py which did not have correct permissions and was not using the correct init script to start Python.

PathExists is the thing that checks to see if your directory exists when you press the button in CreateBatchFiles. It's probably running off of imageweb right now, so no big deal.
