### PR TITLE
Fixes #14 - if centrosome needed, create a virtual environment

### DIFF
--- a/RunBatch.py
+++ b/RunBatch.py
@@ -859,6 +859,14 @@ fi
         cwd = batch.cpcluster
     script += 'cd %s\n' % cwd
     #
+    # If the directory contains a virtualenv, activate it
+    #
+    script += """
+if [ -e ./bin/activate ]; then
+    . ./bin/activate
+fi
+"""
+    #
     # set +e allows the command to error-out without ending this script.
     #        This lets us capture the error status.
     #


### PR DESCRIPTION
BatchProfiler detects whether resources.txt requires centrosome when compiling and then creates a virtual environment within the target directory (it looks like you can both check out to the directory and create a virtual environment within it without conflict, although it is messy). It then pip-installs pytest (because the centrosome install was failing for me if I didn't) and then pip-installs the correct centrosome version from Github. It then activates the virtual environment when compiling CellProfiler.

RunBatch activates the virtual environment when running CellProfiler and everything works.
